### PR TITLE
Add Kokoro CLI text-to-speech support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ pygame
 duckduckgo-search
 scikit-learn
 numpy
+kokoro-tts


### PR DESCRIPTION
## Summary
- add a configurable text-to-speech provider that can route playback through the Kokoro CLI with automatic fallback to OpenAI streaming voices
- document how to install and configure Kokoro on macOS, including new environment variables and credits for the upstream project
- include the kokoro-tts package in the default Python requirements so the CLI is available after installation

## Testing
- python -m compileall assistant.py

------
https://chatgpt.com/codex/tasks/task_e_68d0099651d48321a3a2aa134af8a85a